### PR TITLE
Support anonymising IBAN values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
             <version>1.4</version>
         </dependency>
         <dependency>
+            <groupId>org.iban4j</groupId>
+            <artifactId>iban4j</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.castor</groupId>
             <artifactId>castor-xml</artifactId>
             <version>1.4.1</version>

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/AnonymizerService.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/AnonymizerService.java
@@ -33,6 +33,7 @@ public class AnonymizerService {
 		registerAnonymizer(new CharacterStringAnonymizer());
 		registerAnonymizer(new CharacterStringPrefetchAnonymizer());
 		registerAnonymizer(new DateAnonymizer());
+		registerAnonymizer(new IbanAnonymizer());
 
 		registerAnonymizer(new CountryCodeAnonymizer());
 

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/BankAccountAnonymizer.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/BankAccountAnonymizer.java
@@ -1,0 +1,25 @@
+package com.rolfje.anonimatron.anonymizer;
+
+/**
+ * An {@linkplain Anonymizer} for Bank Accounts.
+ *
+ * @author Erik-Berndt Scheper
+ */
+interface BankAccountAnonymizer extends Anonymizer {
+
+	/**
+	 * Generate a bank account using the given number of digits.
+	 *
+	 * @param numberOfDigits the number of digits in the account number.
+	 * @return the bank account
+	 */
+	String generateBankAccount(int numberOfDigits);
+
+	/**
+	 * Generate a valid bank code.
+	 *
+	 * @return a valid bank code
+	 */
+	String generateBankCode();
+
+}

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/DutchBankAccountAnononymizer.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/DutchBankAccountAnononymizer.java
@@ -1,5 +1,7 @@
 package com.rolfje.anonimatron.anonymizer;
 
+import java.security.SecureRandom;
+
 import org.apache.log4j.Logger;
 
 import com.rolfje.anonimatron.synonyms.StringSynonym;
@@ -15,10 +17,12 @@ import com.rolfje.anonimatron.synonyms.Synonym;
  * <p>
  * See http://nl.wikipedia.org/wiki/Elfproef
  */
-public class DutchBankAccountAnononymizer extends AbstractElevenProofAnonymizer {
+public class DutchBankAccountAnononymizer extends AbstractElevenProofAnonymizer implements BankAccountAnonymizer {
 	private static Logger LOG = Logger.getLogger(DutchBankAccountAnononymizer.class);
 
 	private static int LENGTH = 9;
+
+	private final SecureRandom random = new SecureRandom();
 
 	@Override
 	public String getType() {
@@ -29,12 +33,11 @@ public class DutchBankAccountAnononymizer extends AbstractElevenProofAnonymizer 
 	public Synonym anonymize(Object from, int size) {
 		if (size < LENGTH) {
 			throw new UnsupportedOperationException(
-					"Can not generate a Dutch Bank Account number that fits in a "
-							+ size
-							+ " character string. Must be " + LENGTH + " characters or more.");
+					"Can not generate a Dutch Bank Account number that fits in a " + size + " character string. Must be " + LENGTH
+							+ " characters or more.");
 		}
 
-		int originalLength = ((String)from).length();
+		int originalLength = ((String) from).length();
 		if (originalLength > LENGTH) {
 			LOG.warn("Original bank account number had more than " + LENGTH
 					+ " digits. The resulting anonymous bank account number with the same length will not be a valid account number.");
@@ -53,7 +56,8 @@ public class DutchBankAccountAnononymizer extends AbstractElevenProofAnonymizer 
 		return s;
 	}
 
-	String generateBankAccount(int numberOfDigits) {
+	@Override
+	public String generateBankAccount(int numberOfDigits) {
 		if (numberOfDigits == LENGTH) {
 			// Generate 11-proof bank account number
 			int[] elevenProof = generate11ProofNumber(numberOfDigits);
@@ -62,6 +66,62 @@ public class DutchBankAccountAnononymizer extends AbstractElevenProofAnonymizer 
 			// Generate non-11 proof bank account number
 			int[] randomnumber = getRandomDigits(numberOfDigits);
 			return digitsAsNumber(randomnumber);
+		}
+	}
+
+	@Override
+	public String generateBankCode() {
+		DutchBankCode bankCode = DutchBankCode.values()[random.nextInt(DutchBankCode.values().length)];
+
+		return bankCode.bankCode;
+	}
+
+	/**
+	 * Enumeration of the Dutch bank codes, used to generate valid IBAN for Dutch bank accounts.
+	 *
+	 * @see <a href="Bank Identifier Codes">https://www.betaalvereniging.nl/aandachtsgebieden/giraal-betalingsverkeer/bic-sepa-transacties/</a>
+	 */
+	private enum DutchBankCode {
+
+		ABNA("ABNANL2A", "ABNA", "ABN AMRO"), FTSB("ABNANL2A", "FTSB", "ABN AMRO (ex FORTIS)"), ADYB("ADYBNL2A", "ADYB",
+				"ADYEN"), AEGO("AEGONL2U", "AEGO", "AEGON BANK"), ANAA("ANAANL21", "ANAA", "BRAND NEW DAY (ex ALLIANZ)"), ANDL(
+				"ANDLNL2A", "ANDL", "ANADOLUBANK"), ARBN("ARBNNL22", "ARBN", "ACHMEA BANK"), ARSN("ARSNNL21", "ARSN",
+				"ARGENTA SPAARBANK"), ASNB("ASNBNL21", "ASNB", "ASN BANK"), ATBA("ATBANL2A", "ATBA", "AMSTERDAM TRADE BANK"), BCDM(
+				"BCDMNL22", "BCDM", "BANQUE CHAABI DU MAROC"), BCIT("BCITNL2A", "BCIT", "INTESA SANPAOLO"), BICK("BICKNL2A", "BICK",
+				"BINCKBANK"), BINK("BINKNL21", "BINK", "BINCKBANK, PROF"), BKCH("BKCHNL2R", "BKCH", "BANK OF CHINA"), BKMG(
+				"BKMGNL2A", "BKMG", "BANK MENDES GANS"), BLGW("BLGWNL21", "BLGW", "BLG WONEN"), BMEU("BMEUNL21", "BMEU",
+				"BMCE EUROSERVICES"), BNDA("BNDANL2A", "BNDA", "BRAND NEW DAY BANK"), BNGH("BNGHNL2G", "BNGH",
+				"BANK NEDERLANDSE GEMEENTEN"), BNPA("BNPANL2A", "BNPA", "BNP PARIBAS"), BOFA("BOFANLNX", "BOFA",
+				"BANK OF AMERICA"), BOFS("BOFSNL21002", "BOFS", "BANK OF SCOTLAND, AMSTERDAM"), BOTK("BOTKNL2X", "BOTK",
+				"MUFG BANK"), BUNQ("BUNQNL2A", "BUNQ", "BUNQ"), CHAS("CHASNL2X", "CHAS", "JPMORGAN CHASE"), CITC("CITCNL2A", "CITC",
+				"CITCO BANK"), CITI("CITINL2X", "CITI", "CITIBANK INTERNATIONAL"), COBA("COBANL2X", "COBA", "COMMERZBANK"), DEUT(
+				"DEUTNL2A", "DEUT", "DEUTSCHE BANK (bij alle SEPA transacties)"), DHBN("DHBNNL2R", "DHBN", "DEMIR-HALK BANK"), DLBK(
+				"DLBKNL2A", "DLBK", "DELTA LLOYD BANK"), DNIB("DNIBNL2G", "DNIB", "NIBC"), EBUR("EBURNL21", "EBUR",
+				"EBURY NETHERLANDS"), FBHL("FBHLNL2A", "FBHL", "CREDIT EUROPE BANK"), FLOR("FLORNL2A", "FLOR",
+				"DE NEDERLANDSCHE BANK"), FRGH("FRGHNL21", "FRGH", "FGH BANK"), FRNX("FRNXNL2A", "FRNX", "FRANX"), FVLB("FVLBNL22",
+				"FVLB", "VAN LANSCHOT"), GILL("GILLNL2A", "GILL", "INSINGERGILISSEN"), HAND("HANDNL2A", "HAND",
+				"SVENSKA HANDELSBANKEN"), HHBA("HHBANL22", "HHBA", "HOF HOORNEMAN BANKIERS"), HSBC("HSBCNL2A", "HSBC",
+				"HSBC BANK"), ICBK("ICBKNL2A", "ICBK", "INDUSTRIAL & COMMERCIAL BANK OF CHINA"), INGB("INGBNL2A", "INGB",
+				"ING"), ISAE("ISAENL2A", "ISAE", "CACEIS BANK, Netherlands Branch"), ISBK("ISBKNL2A", "ISBK", "ISBANK"), KABA(
+				"KABANL2A", "KABA", "YAPI KREDI BANK"), KASA("KASANL2A", "KASA", "KAS BANK"), KNAB("KNABNL2H", "KNAB",
+				"KNAB"), KOEX("KOEXNL2A", "KOEX", "KOREA EXCHANGE BANK"), KRED("KREDNL2X", "KRED", "KBC BANK"), LOCY("LOCYNL2A",
+				"LOCY", "LOMBARD ODIER DARIER HENTSCH & CIE"), LOYD("LOYDNL2A", "LOYD", "LLOYDS TSB BANK"), LPLN("LPLNNL2F", "LPLN",
+				"LEASEPLAN CORPORATION"), MHCB("MHCBNL2A", "MHCB", "MIZUHO BANK EUROPE"), MOYO("MOYONL21", "MOYO", "MONEYOU"), NNBA(
+				"NNBANL2G", "NNBA", "NATIONALE-NEDERLANDEN BANK"), NWAB("NWABNL2G", "NWAB", "NEDERLANDSE WATERSCHAPSBANK"), PCBC(
+				"PCBCNL2A", "PCBC", "CHINA CONSTRUCTION BANK, AMSTERDAM BRANCH"), RABO("RABONL2U", "RABO", "RABOBANK"), RBRB(
+				"RBRBNL21", "RBRB", "REGIOBANK"), SOGE("SOGENL2A", "SOGE", "SOCIETE GENERALE"), TEBU("TEBUNL2A", "TEBU",
+				"THE ECONOMY BANK"), TRIO("TRIONL2U", "TRIO", "TRIODOS BANK"), UBSW("UBSWNL2A", "UBSW",
+				"UBS EUROPE SE, NETHERLANDS BRANCH"), UGBI("UGBINL2A", "UGBI", "GARANTIBANK INTERNATIONAL"), VOWA("VOWANL21",
+				"VOWA", "VOLKSWAGEN BANK"), ZWLB("ZWLBNL21", "ZWLB", "SNS (ex ZWITSERLEVENBANK)");
+
+		private final String bic;
+		private final String bankCode;
+		private final String bankNaam;
+
+		DutchBankCode(String bic, String bankCode, String bankNaam) {
+			this.bic = bic;
+			this.bankCode = bankCode;
+			this.bankNaam = bankNaam;
 		}
 	}
 }

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/IbanAnonymizer.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/IbanAnonymizer.java
@@ -1,0 +1,129 @@
+/*
+ *
+ *  ---------------------------------------------------------------------------------------------------------
+ *              Titel: IbanAnonymizer.java
+ *             Auteur: Erik-Berndt Scheper
+ *    Creatietijdstip: 12-6-2018 10:52
+ *          Copyright: (c) 2018 Belastingdienst / Centrum voor Applicatieontwikkeling en Onderhoud,
+ *                     All Rights Reserved.
+ *  ---------------------------------------------------------------------------------------------------------
+ *                                              |   Unpublished work. This computer program includes
+ *     De Belastingdienst                       |   Confidential, Properietary Information and is a
+ *     Postbus 9050                             |   trade Secret of the Belastingdienst. No part of
+ *     7300 GM  Apeldoorn                       |   this file may be reproduced or transmitted in any
+ *     The Netherlands                          |   form or by any means, electronic or mechanical,
+ *     http://belastingdienst.nl/               |   for the purpose, without the express written
+ *                                              |   permission of the copyright holder.
+ *  ---------------------------------------------------------------------------------------------------------
+ *
+ */
+package com.rolfje.anonimatron.anonymizer;
+
+import static org.apache.log4j.Logger.getLogger;
+
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.iban4j.CountryCode;
+import org.iban4j.Iban;
+import org.iban4j.Iban4jException;
+import org.iban4j.bban.BbanStructure;
+
+import com.rolfje.anonimatron.synonyms.StringSynonym;
+import com.rolfje.anonimatron.synonyms.Synonym;
+
+/**
+ * Generates valid International Bank Account Numbers, or {@code IBAN}'s.
+ * Tries to use the {@link BankAccountAnonymizer} to generate valid {@code BBAN}'s for the system default country code.
+ * If no such anonymizer exists, a random account is generated.
+ * <p>
+ *
+ * @author Erik-Berndt Scheper
+ * @see <a href="https://en.wikipedia.org/wiki/International_Bank_Account_Number">https://en.wikipedia.org/wiki/International_Bank_Account_Number</a>
+ */
+public class IbanAnonymizer implements Anonymizer {
+
+	private static final Logger LOGGER = getLogger(IbanAnonymizer.class);
+
+	private static final String TYPE = "IBAN";
+
+	static final Map<CountryCode, BankAccountAnonymizer> BANK_ACCOUNT_ANONYMIZERS;
+	static final CountryCode DEFAULT_COUNTRY_CODE;
+
+	static {
+		// initialize bank account anonymizers
+		BANK_ACCOUNT_ANONYMIZERS = new EnumMap<>(CountryCode.class);
+		BANK_ACCOUNT_ANONYMIZERS.put(CountryCode.NL, new DutchBankAccountAnononymizer());
+
+		// set a default country code to be used when the original iban cannot be parsed
+		CountryCode countryCode = CountryCode.getByCode(Locale.getDefault().getCountry());
+
+		if (countryCode != null && BbanStructure.forCountry(countryCode) != null) {
+			DEFAULT_COUNTRY_CODE = countryCode;
+		} else {
+			DEFAULT_COUNTRY_CODE = CountryCode.NL;
+		}
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	@Override
+	public Synonym anonymize(Object from, int size) {
+
+		CountryCode countryCode = getCountryCode(from);
+		String result = generateIban(countryCode);
+
+		StringSynonym stringSynonym = new StringSynonym();
+		stringSynonym.setFrom(from);
+		stringSynonym.setType(TYPE);
+		stringSynonym.setTo(result);
+
+		return stringSynonym;
+	}
+
+	String generateIban(CountryCode countryCode) {
+		BankAccountAnonymizer bankAccountAnonymizer = BANK_ACCOUNT_ANONYMIZERS.get(countryCode);
+
+		String accountNumber = null;
+		String bankCode = null;
+		if (bankAccountAnonymizer != null) {
+			accountNumber = "0" + bankAccountAnonymizer.generateBankAccount(9);
+			bankCode = bankAccountAnonymizer.generateBankCode();
+		}
+
+		Iban iban = new Iban.Builder().
+				countryCode(countryCode).
+				accountNumber(accountNumber).
+				bankCode(bankCode).
+				buildRandom();
+
+		return iban.toString();
+	}
+
+	private CountryCode getCountryCode(Object from) {
+		CountryCode countryCode = DEFAULT_COUNTRY_CODE;
+
+		if (from instanceof String) {
+			try {
+				Iban iban = Iban.valueOf((String) from);
+
+				// verify this country code is supported for BBAN randomisation
+				if (BbanStructure.forCountry(iban.getCountryCode()) == null) {
+					countryCode = iban.getCountryCode();
+				}
+
+			} catch (Iban4jException ibex) {
+				// ignore
+				LOGGER.trace("Ignoring IBAN value " + from, ibex);
+			}
+		}
+
+		return countryCode;
+	}
+
+}

--- a/src/test/java/com/rolfje/anonimatron/anonymizer/IbanAnonymizerTest.java
+++ b/src/test/java/com/rolfje/anonimatron/anonymizer/IbanAnonymizerTest.java
@@ -1,0 +1,63 @@
+package com.rolfje.anonimatron.anonymizer;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.util.EnumSet;
+
+import org.iban4j.CountryCode;
+import org.iban4j.Iban;
+import org.iban4j.bban.BbanStructure;
+import org.junit.Test;
+
+import com.rolfje.anonimatron.synonyms.Synonym;
+
+/**
+ * Tests for {@link IbanAnonymizer}.
+ *
+ * @author Erik-Berndt Scheper
+ */
+public class IbanAnonymizerTest {
+
+	private IbanAnonymizer anonymizer = new IbanAnonymizer();
+	private EnumSet<CountryCode> countriesWithBankAccountAnonymizer = EnumSet
+			.copyOf(IbanAnonymizer.BANK_ACCOUNT_ANONYMIZERS.keySet());
+	private EnumSet<CountryCode> countriesWithoutBankAccountAnonymizer = EnumSet.complementOf(countriesWithBankAccountAnonymizer);
+
+	@Test
+	public void testAnonymizeForCountriesWithBankAccountAnonymizer() {
+		for (CountryCode countryCode : countriesWithBankAccountAnonymizer) {
+			testAnonymize(countryCode);
+		}
+	}
+
+	@Test
+	public void testAnonymizeForOtherCountries() {
+		for (CountryCode countryCode : countriesWithoutBankAccountAnonymizer) {
+			if (BbanStructure.forCountry(countryCode) != null) {
+				testAnonymize(countryCode);
+			}
+		}
+	}
+
+	private void testAnonymize(CountryCode countryCode) {
+		for (int i = 0; i < 1000; i++) {
+			String source = anonymizer.generateIban(countryCode);
+			assertThat(Iban.valueOf(source).getCountryCode(), anyOf(is(countryCode), is(IbanAnonymizer.DEFAULT_COUNTRY_CODE)));
+
+			testInternal(source.length(), source, countryCode);
+		}
+	}
+
+	private void testInternal(int size, String from, CountryCode countryCode) {
+		Synonym synonym = anonymizer.anonymize(from, size);
+		assertThat(synonym.getType(), sameInstance(anonymizer.getType()));
+
+		String value = (String) synonym.getTo();
+
+		assertThat(Iban.valueOf(value).getCountryCode(), anyOf(is(countryCode), is(IbanAnonymizer.DEFAULT_COUNTRY_CODE)));
+	}
+
+}


### PR DESCRIPTION
This PR implements [anonymisation of IBAN values](https://github.com/realrolfje/anonimatron/issues/28)

The country code of the original IBAN (pre anonymisation) is used to generate the anonymised IBAN. I.e. the new IBAN will have the same country code as the original, unless BBAN generation is not supported by iban4j. In that case a Dutch IBAN will be generated.

I've used `org.iban4j` to generate and validate random IBAN's, and used (actually enhanced) the existing DutchBankAccount generator to generate valid Dutch IBAN's when the original IBAN can be parsed and validated to a Dutch bank account. 

