### PR TITLE
Removed duplicated row from documentation example

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -88,7 +88,6 @@ select * from mydb.userdata;
 | id | firstname | lastname | creditcardnr |
 |----|-----------|----------|--------------|
 | 1  | Homer     | Simpson  | 1234         |
-| 1  | Homer     | Simpson  | 1234         |
 | 2  | Marge     | Simpson  | 5678         |
 | 3  | Ned       | Flanders | 3456         |
 | 4  | Charles   | Burns    | 3456         |


### PR DESCRIPTION
Implementation of solution for [issue XXX](https://github.com/realrolfje/anonimatron/issues/XXX)

The example table in the documentation shows the same row twice. At first I wasn't sure if this was intentional, and I was confused as to why it didn't appear in the output table. But I inferred from the duplicate ID that it was not intentional.