### PR TITLE
Do not update a row if no column was updated

### DIFF
--- a/src/main/java/com/rolfje/anonimatron/jdbc/JdbcAnonymizerService.java
+++ b/src/main/java/com/rolfje/anonimatron/jdbc/JdbcAnonymizerService.java
@@ -196,8 +196,9 @@ public class JdbcAnonymizerService {
                     NDC.pop(); // column
                 }
 
-                // Do not update for read-only resultsets
-                if (results.getConcurrency() == ResultSet.CONCUR_UPDATABLE) {
+                // Do not update for read-only resultsets or if the list of columns to update is empty
+                // If the list is empty, some JDBC implementations (namely Informix) will throw a syntax error.
+                if (results.getConcurrency() == ResultSet.CONCUR_UPDATABLE && !columnsAsList.isEmpty()) {
                     results.updateRow();
                 }
 


### PR DESCRIPTION
Avoid updating a row, if no column was updated (ie no discirimnators
fired). You'd expect this to be a no-op, however at least the Informix
JDBC driver creates a statement with invalid syntax and throws an
exception. To avoid that, we don't run the update at all.

## Reproduction
To reproduce the error you can use the informix docker container:
```bash
docker run -it --name ifx --privileged -p 9088:9088 -p 9089:9089 -p 27017:27017 -p 27018:27018 -p 27883:27883 -e LICENSE=accept ibmcom/informix-developer-database:12.10.FC12W1DE
```
After the docker container initialized, attach a shell to the container:
```bash
docker exec -ti ifx bash
```
Create a script (`createTable.sql`) with the following content to set up the test table;
```sql
CREATE DATABASE hub WITH LOG;

DATABASE hub;

CREATE TABLE t_test(
col1 char(255) PRIMARY KEY,
col2 char(1),
col3 char(255)
);

INSERT INTO t_test VALUES (
"foo", "", "Adelbert"
);

INSERT INTO t_test VALUES (
"bar", "X", "Richart"
);
```
Create the table:
```bash
dbaccess < createTable.sql
```
Run anonimatron with the [problematic config.t_test.txt](https://github.com/realrolfje/anonimatron/files/7758389/config.t_test.txt):
```bash
./anonimatron.sh -config config.t_test.txt -jdbcurl jdbc:informix-sqli://localhost:9088/hub:INFORMIXSERVER=informix -userid informix -password in4mix
```
 
/cc @ubeth (who ran into this issue)