### PR TITLE
Added IPv4 Address Anonymizer

### DIFF
--- a/src/main/java/com/rolfje/anonimatron/anonymizer/AnonymizerService.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/AnonymizerService.java
@@ -35,6 +35,7 @@ public class AnonymizerService {
 		registerAnonymizer(new CharacterStringPrefetchAnonymizer());
 		registerAnonymizer(new DateAnonymizer());
 		registerAnonymizer(new IbanAnonymizer());
+		registerAnonymizer(new IPAddressV4Anonymizer());
 
 		registerAnonymizer(new CountryCodeAnonymizer());
 

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/IPAddressV4Anonymizer.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/IPAddressV4Anonymizer.java
@@ -1,0 +1,49 @@
+package com.rolfje.anonimatron.anonymizer;
+
+import com.rolfje.anonimatron.synonyms.StringSynonym;
+import com.rolfje.anonimatron.synonyms.Synonym;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class IPAddressAnonymizer implements Anonymizer {
+    private static final String TYPE = "IP_ADDRESS_V4";
+
+    @Override
+    public Synonym anonymize(Object from, int size, boolean shortlived) {
+        String to = getString(from, size);
+        return new StringSynonym(
+                getType(),
+                (String) from,
+                to,
+                shortlived
+        );
+    }
+
+    private String ipChunk() {
+        return ThreadLocalRandom.current().nextInt(0, 256).toString();
+    }
+
+    private String getString(Object from, int size) {
+        if (from == null) {
+            return null;
+        }
+
+        if (from instanceof String) {
+            String to = String.format('127.%s.%s.%s', ipChunk(), ipChunk(), ipChunk());
+
+            if (to.length() > size) {
+                throw new UnsupportedOperationException(
+                        "Can not reliably generate a version 4 IP address smaller than " + size + " characters.");
+            }
+            return to;
+
+        }
+
+        throw new UnsupportedOperationException("Can not anonymize objects of type " + from.getClass());
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/com/rolfje/anonimatron/anonymizer/IPAddressV4Anonymizer.java
+++ b/src/main/java/com/rolfje/anonimatron/anonymizer/IPAddressV4Anonymizer.java
@@ -5,7 +5,7 @@ import com.rolfje.anonimatron.synonyms.Synonym;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public class IPAddressAnonymizer implements Anonymizer {
+public class IPAddressV4Anonymizer implements Anonymizer {
     private static final String TYPE = "IP_ADDRESS_V4";
 
     @Override
@@ -19,8 +19,8 @@ public class IPAddressAnonymizer implements Anonymizer {
         );
     }
 
-    private String ipChunk() {
-        return ThreadLocalRandom.current().nextInt(0, 256).toString();
+    private int ipChunk() {
+        return ThreadLocalRandom.current().nextInt(0, 256);
     }
 
     private String getString(Object from, int size) {
@@ -29,7 +29,7 @@ public class IPAddressAnonymizer implements Anonymizer {
         }
 
         if (from instanceof String) {
-            String to = String.format('127.%s.%s.%s', ipChunk(), ipChunk(), ipChunk());
+            String to = String.format("127.%d.%d.%d", ipChunk(), ipChunk(), ipChunk());
 
             if (to.length() > size) {
                 throw new UnsupportedOperationException(

--- a/src/test/java/com/rolfje/anonimatron/anonymizer/IPAddressV4AnonymizerTest.java
+++ b/src/test/java/com/rolfje/anonimatron/anonymizer/IPAddressV4AnonymizerTest.java
@@ -1,0 +1,46 @@
+package com.rolfje.anonimatron.anonymizer;
+
+import com.rolfje.anonimatron.synonyms.Synonym;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class IPAddressV4AnonymizerTest {
+
+    private IPAddressV4Anonymizer ipAnonymizer;
+
+    @Before
+    public void setUp() {
+        ipAnonymizer = new IPAddressV4Anonymizer();
+    }
+
+    @Test
+    public void testHappyFlow() {
+        Synonym synonym = ipAnonymizer.anonymize("192.168.1.1", Integer.MAX_VALUE, false);
+
+        assertNotEquals(synonym.getFrom(), synonym.getTo());
+        assertEquals(ipAnonymizer.getType(), synonym.getType());
+        assertFalse(synonym.isShortLived());
+        // Example from anonymizer is 127.243.0.15
+        assertTrue(Pattern.matches("^127\\.[\\d]{1,3}\\.[\\d]{1,3}\\.[\\d]{1,3}$", synonym.getTo().toString()));
+    }
+
+    @Test
+    public void testNullInput() {
+        Synonym synonym = ipAnonymizer.anonymize(null, Integer.MAX_VALUE, true);
+        assertNull(synonym.getFrom());
+        assertNull(synonym.getTo());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIncorrectInputType() {
+        ipAnonymizer.anonymize(new Long(0), Integer.MAX_VALUE, true);
+    }
+}


### PR DESCRIPTION
This adds an IP address anonymizer so that users can anonymize IP addresses in their dataset. It always replaces with 127.x.x.x IP addresses, which are localhost.