### PR TITLE
Add add-opens to be able to run Anonimatron in newer jvms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -146,8 +146,16 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <argLine>--add-opens java.xml/com.sun.org.apache.xml.internal.serialize=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.3</version>
                 <configuration>
                     <stylesheetfile>${basedir}/src/javadoc/stylesheet.css</stylesheetfile>
                 </configuration>
@@ -194,7 +202,7 @@
                         <!-- Signs all deployable artifacts during "verify" stage -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.2</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/resources/scripts/anonimatron.bat
+++ b/resources/scripts/anonimatron.bat
@@ -1,2 +1,2 @@
 @echo off
-java -Xmx2G -classpath *;./libraries/*;./jdbcdrivers/*;./anonymizers/* com.rolfje.anonimatron.Anonimatron %*
+java -Xmx2G --add-opens java.xml/com.sun.org.apache.xml.internal.serialize=ALL-UNNAMED -classpath *;./libraries/*;./jdbcdrivers/*;./anonymizers/* com.rolfje.anonimatron.Anonimatron %*

--- a/resources/scripts/anonimatron.sh
+++ b/resources/scripts/anonimatron.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 cd -P "$(dirname $0)"
-java ${JAVA_OPTS:='-Xmx2G'} -classpath *:./libraries/*:./jdbcdrivers/*:./anonymizers/* com.rolfje.anonimatron.Anonimatron $*
+java ${JAVA_OPTS:='-Xmx2G'} --add-opens java.xml/com.sun.org.apache.xml.internal.serialize=ALL-UNNAMED -classpath *:./libraries/*:./jdbcdrivers/*:./anonymizers/* com.rolfje.anonimatron.Anonimatron $*
 cd -


### PR DESCRIPTION
When trying to make a release on openJDK22, I ran into the need for the "add-opens" trickery. Added it. Hope it works for older jvms.